### PR TITLE
Fix typo with injected spring value

### DIFF
--- a/ladon-s3-server-boot/src/main/java/de/mc/ladon/s3server/config/BeanConfig.java
+++ b/ladon-s3-server-boot/src/main/java/de/mc/ladon/s3server/config/BeanConfig.java
@@ -30,7 +30,7 @@ public class BeanConfig {
 
     @Value("${s3server.fsrepo.root}")
     String fsRepoRoot;
-    @Value("${s3server.fsrepo.secret")
+    @Value("${s3server.fsrepo.secret}")
     String encSecret;
 
     @ConditionalOnMissingBean


### PR DESCRIPTION
`@Value("${s3server.fsrepo.secret")` should be `@Value("${s3server.fsrepo.secret}")`